### PR TITLE
Also print output in order to see latexmk errors

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,5 @@
 ARG scheme
 FROM strauman/tex:tl-$scheme
-RUN tlmgr install lipsum pgf koma-script xcolor
 
 RUN mkdir /repo/
 WORKDIR /repo

--- a/docker/execute_tests.sh
+++ b/docker/execute_tests.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 repo_dir="/repo";
 pdfsdir="$repo_dir/pdfs"
 
@@ -7,10 +9,10 @@ function echo_errors(){
     echo "!!!ERR:-----------------------";
     cat tmpstderror;
   fi
-  if [ -f "tmpstderror" ];then
+  if [ -f "tmpstdout" ];then
     echo "----------:::::::::----------";
     echo "!!!OUT:-----------------------";
-    cat tmpstderror;
+    cat tmpstdout;
   fi
   echo "----------:::::::::----------";
 }


### PR DESCRIPTION
This was the indirect cause of the error: there was `tmpstderror` twice in the shell file, so I couldn't see the output of latexmk which shows in the log (also on Travis, I hope) what exactly went wrong. Now `tmpstdout` is printed as well.

PS Your explanation of docker was spot on, it was very easy to find this bug now with the correct commands :) 