### PR TITLE
Only clean up temporary files of the file that is to be build

### DIFF
--- a/docker/execute_tests.sh
+++ b/docker/execute_tests.sh
@@ -93,7 +93,7 @@ do
   fi
   cd "$dirname";
   echo "Building $texfile_full"
-  latexmk -C ${buildflags} > /dev/null 2>/dev/null
+  latexmk -C ${buildflags} "$filename" > /dev/null 2>/dev/null
   latexmk -pdf --shell-escape -f -interaction=nonstopmode ${buildflags} "$filename" >tmpstdout 2>tmpstderror
   exitCode=$?
   # "Error when building $texfile_full.tex"


### PR DESCRIPTION
When you clean all temporary files before building, it seems you are also removing other pdf files - hence only the pdf of the last compiled file remains to be pushed to releases.

I tested the current docker image, and both files are compiled but only one pdf is uploaded:
see build https://travis-ci.org/PHPirates/travis-ci-latex-pdf/builds/441280554
with result https://github.com/PHPirates/travis-ci-latex-pdf/releases/tag/test-v23

I also confirmed the bug locally (two tex files in same directory, only pdf of last compiled one is left) and the fix works for me.

PS I see you changed your main branch, but are you uploading the docker image to the hub from the code at master?