### PR TITLE
Texliveonfly (or: install package dependencies automatically)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.log
 *.fdb_latexmk
 .idea/
+*.iml

--- a/README.md
+++ b/README.md
@@ -62,15 +62,16 @@ tex-config:
 
 Which TeX-scheme to use; this is, basically, how many packages are installed on the docker image by default.
 - `full`: Full contains most of the packages in CTAN and has a docker image of 3GB that needs to be downloaded every time.
-- `small`: contains only the bare necessities, missing packages will be attempted to be installed using `texliveonfly`. You can manually add packages that you wish to installed using the `packages` option.
+- `small`: contains only the bare necessities, and probably will most of the packages that you wish to used be specified in the `packages` option.
 (- `medium`: Coming later)
+- `texliveonfly`: Is the `small` image, but missing packages will be attempted to be installed using `texliveonfly`. You can still manually add packages that you wish to installed using the `packages` option.
 
 ## `packages`
 - Accepted values: comma (**not** space) separated list
 - Default value: _empty_
 
 What packages should also be installed using TeXLives `tlmgr` before running the TeX-files.
-Note that `texliveonfly` will attempt to install missing packages automatically.
+Note that when using the `texliveonfly` image, it will attempt to install missing packages automatically.
 
 ## `latexmk-flags`
 - Specify compile flags to latexmk, for example `-dvi`

--- a/README.md
+++ b/README.md
@@ -108,4 +108,4 @@ Building the docker image
 
 Running the docker image
 * To test in this repo you can use `testrun.sh`
-* To run elsewhere you can use `docker run --mount src="/full/path/to/repo",target=/repo,type=bind mytagname:latest` or interactively (so you can play around inside the container) with `docker run -it --mount src="/home/thomas/GitRepos/random-tex",target=/repo,type=bind mytagname:latest /bin/sh`
+* To run elsewhere you can use `docker run --mount src="/full/path/to/repo",target=/repo,type=bind mytagname:latest` or interactively (so you can play around inside the container) with `docker run -it --mount src="/full/path/to/repo",target=/repo,type=bind mytagname:latest /bin/sh`

--- a/README.md
+++ b/README.md
@@ -62,14 +62,15 @@ tex-config:
 
 Which TeX-scheme to use; this is, basically, how many packages are installed on the docker image by default.
 - `full`: Full contains most of the packages in CTAN and has a docker image of 3GB that needs to be downloaded every time.
-- `small`: contains only the bare necessities, and probably will most of the packages that you wish to used be specified in the `packages` option
+- `small`: contains only the bare necessities, missing packages will be attempted to be installed using `texliveonfly`. You can manually add packages that you wish to installed using the `packages` option.
 (- `medium`: Coming later)
 
 ## `packages`
 - Accepted values: comma (**not** space) separated list
 - Default value: _empty_
 
-What packages should be installed using TeXLives `tlmgr` before running the TeX-files.
+What packages should also be installed using TeXLives `tlmgr` before running the TeX-files.
+Note that `texliveonfly` will attempt to install missing packages automatically.
 
 ## `latexmk-flags`
 - Specify compile flags to latexmk, for example `-dvi`

--- a/README.md
+++ b/README.md
@@ -91,3 +91,21 @@ Where to publish the pdfs generated. The option for pushing to `release` is comi
 ## Contributing
 
 Talk about the files, tex profiles and so forth.
+
+## Instructions for building the docker image on Linux (using IntelliJ)
+
+* Install docker.
+Post-installation steps from [docs.docker.com](https://docs.docker.com/install/linux/linux-postinstall/#manage-docker-as-a-non-root-user):
+* Make sure you have a docker group (it may exist already) with `sudo groupadd docker`
+* Add your user to the docker group with `sudo usermod -aG docker $USER`
+* Start docker service, for example with `sudo systemctl start docker`
+
+Building the docker image
+* You can create a run configuration using the gutter icon in the Docker file, but you need to pass a parameter. Edit the run configuration, add a build arg `scheme` with value `small`.
+* In the run configuration, you can add an image tag name to find back your image more easily.
+* After the build has finished ('deployed' locally) you can find an overview of images on your computer in the Docker tab.
+* An instance of an image is called a container.
+
+Running the docker image
+* To test in this repo you can use `testrun.sh`
+* To run elsewhere you can use `docker run --mount src="/full/path/to/repo",target=/repo,type=bind mytagname:latest` or interactively (so you can play around inside the container) with `docker run -it --mount src="/home/thomas/GitRepos/random-tex",target=/repo,type=bind mytagname:latest /bin/sh`

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 ARG scheme
-FROM phpirates/tex:tl-${scheme}-2018
+FROM strauman/tex:tl-${scheme}-2019
 
 RUN mkdir /repo/
 WORKDIR /repo
@@ -9,6 +9,7 @@ RUN apk add --no-cache --update python3
 # Put it in path as python instead of python3
 RUN ln -s /usr/bin/python3 /usr/bin/python
 # Install texliveonfly to download package dependencies automatically
+RUN tlmgr update --self
 RUN tlmgr install texliveonfly
 
 RUN apk add --no-cache vim git

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,6 +8,7 @@ WORKDIR /repo
 RUN apk add --no-cache --update python3
 # Put it in path as python instead of python3
 RUN ln -s /usr/bin/python3 /usr/bin/python
+# Install texliveonfly to download package dependencies automatically
 RUN tlmgr install texliveonfly
 
 RUN apk add --no-cache vim git

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,8 @@
 ARG scheme
 FROM strauman/tex:tl-$scheme
+# Python is required by texliveonfly
+#FROM python:latest
+RUN apk-install python
 
 RUN mkdir /repo/
 WORKDIR /repo

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,9 +5,12 @@ RUN mkdir /repo/
 WORKDIR /repo
 
 # Python is required by texliveonfly
-RUN apk-install python
+RUN apk add --no-cache --update python3
+# Put it in path as python instead of python3
+RUN ln -s /usr/bin/python3 /usr/bin/python
+RUN tlmgr install texliveonfly
 
-RUN apk-install vim git
+RUN apk add --no-cache vim git
 
 COPY execute_tests.sh "/usr/bin/execute_tests"
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,11 +1,11 @@
 ARG scheme
 FROM strauman/tex:tl-$scheme
-# Python is required by texliveonfly
-#FROM python:latest
-RUN apk-install python
 
 RUN mkdir /repo/
 WORKDIR /repo
+
+# Python is required by texliveonfly
+RUN apk-install python
 
 RUN apk-install vim git
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,10 +1,10 @@
 ARG scheme
-FROM strauman/tex:tl-$scheme
+FROM phpirates/tex:tl-${scheme}-2018
 
 RUN mkdir /repo/
 WORKDIR /repo
 
-RUN apk-install vim git
+RUN apk add --no-cache vim git
 
 COPY execute_tests.sh "/usr/bin/execute_tests"
 

--- a/docker/execute_tests.sh
+++ b/docker/execute_tests.sh
@@ -47,6 +47,8 @@ packages=${packages//,/ }
 packages=${packages//$'\n'/}
 # First update tlmgr itself
 tlmgr update --self
+# Install texliveonfly (to download packages automatically)
+tlmgr install texliveonfly
 # If we have packages to install
 if [ ! -z "$packages" ]; then
   packages_comma=${packages// /, }
@@ -95,8 +97,13 @@ do
   fi
   cd "$dirname";
   echo "Building $texfile_full"
+
+  # Clean auxiliary files for this particular file using latexmk
   latexmk -C ${buildflags} "$filename" > /dev/null 2>/dev/null
-  latexmk -pdf --shell-escape -f -interaction=nonstopmode ${buildflags} "$filename" >tmpstdout 2>tmpstderror
+
+  # Wrap latexmk with texliveonfly to download missing packages automatically
+  texliveonfly --compiler=latexmk --arguments='-pdf --shell-escape -f -interaction=nonstopmode ${buildflags}' "$filename" >tmpstdout 2>tmpstderror
+
   exitCode=$?
   # "Error when building $texfile_full.tex"
   # Did we want it to fail?

--- a/docker/execute_tests.sh
+++ b/docker/execute_tests.sh
@@ -47,8 +47,6 @@ packages=${packages//,/ }
 packages=${packages//$'\n'/}
 # First update tlmgr itself
 tlmgr update --self
-# Install texliveonfly (to download packages automatically)
-tlmgr install texliveonfly
 # If we have packages to install
 if [ ! -z "$packages" ]; then
   packages_comma=${packages// /, }
@@ -100,9 +98,8 @@ do
 
   # Clean auxiliary files for this particular file using latexmk
   latexmk -C ${buildflags} "$filename" > /dev/null 2>/dev/null
-
   # Wrap latexmk with texliveonfly to download missing packages automatically
-  texliveonfly --compiler=latexmk --arguments='-pdf --shell-escape -f -interaction=nonstopmode ${buildflags}' "$filename" >tmpstdout 2>tmpstderror
+  texliveonfly --compiler=latexmk --arguments="-pdf --shell-escape -f -interaction=nonstopmode ${buildflags}" "$filename" >tmpstdout 2>tmpstderror
 
   exitCode=$?
   # "Error when building $texfile_full.tex"

--- a/docker/execute_tests.sh
+++ b/docker/execute_tests.sh
@@ -98,8 +98,10 @@ do
 
   # Clean auxiliary files for this particular file using latexmk
   latexmk -C ${buildflags} "$filename" > /dev/null 2>/dev/null
-  # Wrap latexmk with texliveonfly to download missing packages automatically
-  texliveonfly --compiler=latexmk --arguments="-pdf --shell-escape -f -interaction=nonstopmode ${buildflags}" "$filename" >tmpstdout 2>tmpstderror
+  # First use texliveonfly to download missing packages automatically
+  # Do not give latexmk as parameter to texliveonfly because that sometimes hangs
+  texliveonfly "$filename" >tmpstdout 2>tmpstderror
+  latexmk -pdf --shell-escape -f -interaction=nonstopmode ${buildflags} "$filename" >tmpstdout 2>tmpstderror
 
   exitCode=$?
   # "Error when building $texfile_full.tex"

--- a/docker/texliveonfly/Dockerfile
+++ b/docker/texliveonfly/Dockerfile
@@ -1,0 +1,13 @@
+ARG scheme
+FROM strauman/tex:tl-${scheme}-2019
+
+RUN mkdir /repo/
+WORKDIR /repo
+
+RUN apk add --no-cache vim git
+
+COPY execute_tests.sh "/usr/bin/execute_tests"
+
+RUN chmod +x "/usr/bin/execute_tests"
+
+CMD execute_tests

--- a/docker/texliveonfly/execute_tests.sh
+++ b/docker/texliveonfly/execute_tests.sh
@@ -98,6 +98,9 @@ do
 
   # Clean auxiliary files for this particular file using latexmk
   latexmk -C ${buildflags} "$filename" > /dev/null 2>/dev/null
+  # First use texliveonfly to download missing packages automatically
+  # Do not give latexmk as parameter to texliveonfly because that sometimes hangs
+  texliveonfly "$filename" >tmpstdout 2>tmpstderror
   latexmk -pdf --shell-escape -f -interaction=nonstopmode ${buildflags} "$filename" >tmpstdout 2>tmpstderror
 
   exitCode=$?

--- a/docker/texliveonfly/readme.md
+++ b/docker/texliveonfly/readme.md
@@ -1,0 +1,1 @@
+This directory contains a docker image which will run texliveonfly to attempt to install LaTeX packages automatically.

--- a/quickstart/.travis.yml
+++ b/quickstart/.travis.yml
@@ -9,5 +9,4 @@ tex-config:
 - packages=lipsum, blindtext
 
 script:
-- docker pull strauman/travis-latexbuild:small # select small texlive scheme
-- docker run --mount src=$TRAVIS_BUILD_DIR/,target=/repo,type=bind strauman/travis-latexbuild:small # also it here
+- docker run --mount src=$TRAVIS_BUILD_DIR/,target=/repo,type=bind strauman/travis-latexbuild:small # Select small TeX Live scheme


### PR DESCRIPTION
This fixes #21.

**Update** It's being tested, see https://github.com/PHPirates/travis-ci-latex-pdf#using-a-docker-image-with-texlive-and-texliveonfly

Sorry for the long story :smile: essentially you should be able to run this, after building Strauman/latex-docker#4

**Changes**
* Add texliveonfly to the compile toolchain, i.e. texliveonfly calls latexmk calls pdflatex.
I think this is backwards compatible, i.e. everything that compiled with latexmk will compile with texliveonfly (provided that it calls latexmk).

* Removed the docker pull command from the .travis.yml, since docker run will also docker pull automatically if needed.

* Oh, and I also added build instructions because I kept forgetting how things worked. I hope you don't mind.

**Dependencies**
This depends on Strauman/latex-docker#4 in order to install Python using apk.

**Other comments**


One disadvantage: the docker image is bigger now because it includes Python. Locally, the `strauman/tex` image is 278MB (compared to 129MB on Docker Hub), and this image is 384MB (compared to 145MB on Hub). Maybe it could get smaller by using something like https://github.com/jfloff/alpine-python

Note I installed texliveonfly in the dockerfile instead of execute_tests, which has the advantage that it will also be available when running the docker image in interactive mode (correct me if I'm wrong).

Also managed to test this locally, understanding a bit more of docker now :smile: 
When I run the docker image interactively (otherwise you can only see stdout if something fails) I verified that for some test file `latexmk main.tex` failed because of missing dependencies, and `texliveonfly main.tex` worked.

- [x] Do a final test on Travis. I think this requires uploading something to docker hub so I didn't do this yet.

**Discussion**

Should this get a new tag, like `:small_v2`? Because suppose it does break builds, then by uploading a new docker image under the same `:small` tag then  this could break everyone's builds, right? I mean, I guess we should use tags like they were meant.
I'm not sure if this should also be added to the medium and full images. I suppose with a full image texliveonfly is not needed.

