### PR TITLE
Use texlive 2018 image with fixed tlmgr package repo

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,10 +1,10 @@
 ARG scheme
-FROM strauman/tex:tl-$scheme
+FROM phpirates/tex:tl-${scheme}-2018
 
 RUN mkdir /repo/
 WORKDIR /repo
 
-RUN apk-install vim git
+RUN apk add --no-cache vim git
 
 COPY execute_tests.sh "/usr/bin/execute_tests"
 


### PR DESCRIPTION
Fixes #23
Depends on Strauman/latex-docker#5 (and if that one is uploaded to Docker up, the first change is not necessary anymore).

Note that this has already been uploaded at https://hub.docker.com/r/phpirates/texlive-latexbuild