### PR TITLE
travis command missing a verb

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ If you're reading this at docker hub, you probably want to head on over to the [
 5.  **If you want the push-branch or push-release functionality, do the following**
     1.  Go to  [github personal access tokens](https://github.com/settings/tokens) and generate a new token
     2.  You need to encrypt your github token, via travis, and add it to the `.travis.yml`. If have ruby (gem) installed you can do:
-    -   `cd` into your git repo and run `gem install travis; travis GH_TOKEN=YOURTOKEN --add` (replacing `YOURTOKEN` with the generated token).
+    -   `cd` into your git repo and run `gem install travis; travis encrypt GH_TOKEN=YOURTOKEN --add` (replacing `YOURTOKEN` with the generated token).
     -   If the above doesn't work (or you don' know what ruby gems are), you need to install ruby on your machine first.
     -   More information about this step is found on [travis documentation on encryption keys](https://docs.travis-ci.com/user/encryption-keys) and [travis documentation on environment variables](https://docs.travis-ci.com/user/environment-variables/#defining-encrypted-variables-in-travisyml)
 


### PR DESCRIPTION
In recent versions of the `travis` gem, the command is `travis encrypt VARIABLE=VALUE --add`.